### PR TITLE
Updates and Completes User Story 17

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,3 +8,5 @@
   <p>State: <%= @current_user.state %></p>
   <p>Zipcode: <%= @current_user.zipcode %></p>
 </div>
+
+<%= link_to "Edit Profile", edit_user_path(@current_user) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     resources :users, only: [:index]
   end
 
-  resources :users, only: [:create]
+  resources :users, only: [:create, :edit]
   resources :merchants, only: [:index]
   resources :items
   resources :orders

--- a/spec/features/user_sees_data_on_profile_page_spec.rb
+++ b/spec/features/user_sees_data_on_profile_page_spec.rb
@@ -16,12 +16,13 @@ describe 'as a registered user' do
 
       visit profile_path
 
-      expect(page).to have_content(user.name)
-      expect(page).to have_content(user.email)
-      expect(page).to have_content(user.address)
-      expect(page).to have_content(user.city)
-      expect(page).to have_content(user.state)
-      expect(page).to have_content(user.zipcode)
+      expect(page).to have_content("Name: #{user.name}")
+      expect(page).to have_content("Email: #{user.email}")
+      expect(page).to have_content("Address: #{user.address}")
+      expect(page).to have_content("City: #{user.city}")
+      expect(page).to have_content("State: #{user.state}")
+      expect(page).to have_content("Zipcode: #{user.zipcode}")
+      expect(page).to_not have_content(user.password)
       expect(page).to have_link("Edit Profile")
     end
   end

--- a/spec/features/user_sees_data_on_profile_page_spec.rb
+++ b/spec/features/user_sees_data_on_profile_page_spec.rb
@@ -22,6 +22,7 @@ describe 'as a registered user' do
       expect(page).to have_content(user.city)
       expect(page).to have_content(user.state)
       expect(page).to have_content(user.zipcode)
+      expect(page).to have_link("Edit Profile")
     end
   end
 end


### PR DESCRIPTION
Resolves #55 and #88.

Adds link to edit profile page in user profile.  

Adds test make sure password is not viewed on profile page. Updates other tests to user interpolation. All tests passing. 

Completes User Story 17, User Profile Show Page

As a registered user
When I visit my own profile page
Then I see all of my profile data on the page except my password
And I see a link to edit my profile data