### PR TITLE
Registration missing info

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,6 +27,6 @@ class UsersController < ApplicationController
   private
 
     def user_params
-      params.require(:user).permit(:name, :address, :city, :state, :zipcode, :email, :password, :role)
+      params.require(:user).permit(:name, :address, :city, :state, :zipcode, :email, :password, :password_confirmation, :role)
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,6 +19,7 @@ class UsersController < ApplicationController
       flash[:success] = "You are now registered & logged in!"
       redirect_to profile_path
     else
+      flash[:error] = "Error: Missing required information"
       render :new
     end
   end

--- a/spec/features/user_can_register_for_site_spec.rb
+++ b/spec/features/user_can_register_for_site_spec.rb
@@ -5,7 +5,6 @@ describe 'As a visitor' do
     user = build(:user)
 
     visit root_path
-
     click_on "Register"
 
     expect(current_path).to eq(register_path)
@@ -24,11 +23,11 @@ describe 'As a visitor' do
     expect(page).to have_content("Welcome, #{user.email}")
     expect(current_path).to eq(profile_path)
   end
-  it 'display flash message for a successful registration' do
+
+  it 'displays flash message for a successful registration' do
     user = build(:user)
 
     visit root_path
-
     click_on "Register"
 
     expect(current_path).to eq(register_path)
@@ -46,4 +45,29 @@ describe 'As a visitor' do
 
     expect(page).to have_content("You are now registered & logged in!")
   end
+
+  it 'will not allow registration if details are missing' do
+    user = build(:user)
+
+    visit root_path
+    click_on "Register"
+
+    fill_in :user_name, with: user.name
+    fill_in :user_email, with: user.email
+    fill_in :user_password, with: user.password
+    fill_in :user_password_confirmation, with: user.password
+    fill_in :user_city, with: user.city
+    fill_in :user_state, with: user.state
+    fill_in :user_zipcode, with: user.zipcode
+
+    click_on "Create User"
+
+    expect(current_path).to eq(users_path)
+    expect(page).to have_content("Error: Missing required information")
+  end
+
+
+
+
+
 end

--- a/spec/features/user_can_register_for_site_spec.rb
+++ b/spec/features/user_can_register_for_site_spec.rb
@@ -66,6 +66,31 @@ describe 'As a visitor' do
     expect(page).to have_content("Error: Missing required information")
   end
 
+  it 'confirms password' do
+    user = build(:user)
+
+
+    visit root_path
+    click_on "Register"
+
+    fill_in :user_name, with: user.name
+    fill_in :user_email, with: user.email
+    fill_in :user_password, with: user.password
+    fill_in :user_password_confirmation, with: "dogparty"
+    fill_in :user_address, with: user.address
+    fill_in :user_city, with: user.city
+    fill_in :user_state, with: user.state
+    fill_in :user_zipcode, with: user.zipcode
+
+    expect(page).to have_content("Password confirmation")
+
+    click_on "Create User"
+
+    expect(current_path).to eq(users_path)
+    expect(page).to have_content("Error: Missing required information")
+  end
+
+
 
 
 


### PR DESCRIPTION
Resolves #67 User Story 8

Adds flash message for missing required fields. Adds test for password confirmation (user story 7).  All tests passing.  

May need to adjust paths for render :new if the user doesn't save, unable to get it to return to '/register/' (goes to '/users' but renders page with previously filled in info)


----------
User Story 8
User Registration Missing Details

As a visitor
When I visit the user registration page
And I do not fill in this form completely,
I am returned to the registration page
And I see a flash message indicating that I am missing required fields