### PR TITLE
User Story 20, User Editing Profile Data must have unique Email address

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,9 +32,14 @@ class UsersController < ApplicationController
   end
 
   def update
-    current_user.update(user_params)
-    flash[:success] = "Your information has been updated."
-    redirect_to profile_path
+    @user = current_user
+    if current_user.update(user_params)
+      flash[:success] = "Your information has been updated."
+      redirect_to profile_path
+    else
+      flash[:error] = "The email entered is already in use"
+      render :new
+    end
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,11 @@ Rails.application.routes.draw do
 
   get '/profile', to: 'users#show'
   namespace :profile do
+
     resources :orders, only: [:show, :index]
   end
+
+  get "/profile/edit", to: "users#edit"
 
   resources :users, only: [:create, :edit, :update] do
     resources :orders, only: [:show]
@@ -34,7 +37,6 @@ Rails.application.routes.draw do
 
   get '/merchants', to: "users#index"
 
-  get "/profile/edit", to: "users#edit"
 
   get '/login', to: "sessions#new"
   post '/login', to: "sessions#create"

--- a/spec/features/users/user_can_edit_profile_spec.rb
+++ b/spec/features/users/user_can_edit_profile_spec.rb
@@ -75,9 +75,10 @@ describe 'as a registered user' do
       fill_in :user_zipcode, with: new_zipcode
 
       click_on "Update User"
-      save_and_open_page
       expect(page).to have_content("The email entered is already in use")
       expect(page).to have_button("Update User")
+      expect(page).to_not have_content("Your information has been updated.")
+      expect(page).to_not have_content(user_2.email)
     end
 
   end

--- a/spec/features/users/user_can_edit_profile_spec.rb
+++ b/spec/features/users/user_can_edit_profile_spec.rb
@@ -52,5 +52,33 @@ describe 'as a registered user' do
       expect(page).to_not have_content(@user.state)
       expect(page).to_not have_content(@user.zipcode)
     end
+
+    it 'shows a flash message if a duplicate email is entered' do
+      user_2 = create(:user, email: "ali@aol.com")
+      new_name = "Tom"
+      new_email = "test@test.com"
+      new_password = "ILoveMom"
+      new_address = "125 Main St."
+      new_city = "Zaregerege"
+      new_state = "ZZ"
+      new_zipcode = 12345
+
+      click_link "Edit Profile"
+
+      fill_in :user_name, with: new_name
+      fill_in :user_email, with: user_2.email
+      fill_in :user_password, with: new_password
+      fill_in :user_password_confirmation, with: new_password
+      fill_in :user_address, with: new_address
+      fill_in :user_city, with: new_city
+      fill_in :user_state, with: new_state
+      fill_in :user_zipcode, with: new_zipcode
+
+      click_on "Update User"
+      save_and_open_page
+      expect(page).to have_content("The email entered is already in use")
+      expect(page).to have_button("Update User")
+    end
+
   end
 end


### PR DESCRIPTION
Closes #52 User Story

Adds a flash message that an email is already in use if a user puts in a duplicate email on the edit profile page.   Test passing

User Story 20, User Editing Profile Data must have unique Email address
As a registered user
When I attempt to edit my profile data
If I try to change my email address to one that belongs to another user
When I submit the form
Then I am returned to the profile edit page
And I see a flash message telling me that email address is already in use