### PR TITLE
User Story 22- Admin Can Edit User Profile

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -7,4 +7,9 @@ class Admin::UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
   end
+
+  def edit
+    @user = User.find(params[:id])
+  end
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,12 +32,14 @@ class UsersController < ApplicationController
   end
 
   def update
-    current_user.update(user_params)
-    flash[:success] = "Your information has been updated."
     if current_user.role == "admin"
-      redirect_to admin_user_path
-      binding.pry
+      @user = User.find(params[:id])
+      @user.update(user_params)
+      flash[:success] = "#{@user.name}'s information has been updated."
+      redirect_to admin_user_path(@user)
     else
+      current_user.update(user_params)
+      flash[:success] = "Your information has been updated."
       redirect_to profile_path
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,7 +34,12 @@ class UsersController < ApplicationController
   def update
     current_user.update(user_params)
     flash[:success] = "Your information has been updated."
-    redirect_to profile_path
+    if current_user.role == "admin"
+      redirect_to admin_user_path
+      binding.pry
+    else
+      redirect_to profile_path
+    end
   end
 
   private

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,23 @@
+<h1>Edit User Profile:</h1>
+<%= form_for @user do |f| %>
+
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <%= f.label :email %>
+  <%= f.email_field :email %>
+  <%= f.label :password %>
+  <%= f.password_field :password %>
+  <%= f.label :password_confirmation %>
+  <%= f.password_field :password_confirmation %>
+  <%= f.label :address %>
+  <%= f.text_field :address %>
+  <%= f.label :city %>
+  <%= f.text_field :city %>
+  <%= f.label :state %>
+  <%= f.text_field :state %>
+  <%= f.label :zipcode %>
+  <%= f.number_field :zipcode %>
+
+  <%= f.submit %>
+
+<% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -9,4 +9,4 @@
   <p>Zipcode: <%= @user.zipcode %></p>
 </div>
 
-<%= link_to "Edit Profile", edit_user_path(@user) %>
+<%= link_to "Edit Profile", edit_admin_user_path(@user) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root 'root#index'
 
   namespace :admin do
-    resources :users, only: [:index, :show, :edit]
+    resources :users, only: [:index, :show, :edit, :update]
     resources :merchants, only: [:show]
     resources :orders, only: [:show]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root 'root#index'
 
   namespace :admin do
-    resources :users, only: [:index, :show]
+    resources :users, only: [:index, :show, :edit]
     resources :merchants, only: [:show]
     resources :orders, only: [:show]
   end

--- a/spec/features/admins/admin_can_edit_user_profile_spec.rb
+++ b/spec/features/admins/admin_can_edit_user_profile_spec.rb
@@ -4,19 +4,12 @@ describe 'as an Admin' do
   it 'allows admin to edit users profile' do
     admin = create(:user, role: 2)
     user_1 = create(:user)
-    user_2 = create(:user)
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
     visit admin_user_path(user_1)
 
     click_link "Edit Profile"
-
-    expect(current_path).to eq(edit_user_path(user_1))
-
-    admin = create(:user, role: 2)
-    user_1 = create(:user)
-    user_2 = create(:user)
 
     new_name = "Wanda"
     new_email = "wanda@aol.com"
@@ -34,9 +27,15 @@ describe 'as an Admin' do
     fill_in :user_city, with: new_city
     fill_in :user_state, with: new_state
     fill_in :user_zipcode, with: new_zipcode
-    binding.pry
+
     click_on "Update User"
-    save_and_open_page
-    expect(current_path).to eq(admin_user_path(user_1))
+
+    expect(page).to have_content("Name: #{new_name}")
+    expect(page).to have_content("Email: #{new_email}")
+    expect(page).to have_content("#{new_name}'s information has been updated.")
+    expect(page).to have_content("Logged in as: #{admin.name}")
+    expect(page).to_not have_content("Your information has been updated.")
+    expect(page).to_not have_content("Name: #{user_1.name}")
+    expect(page).to_not have_content("Email: #{user_1.email}")
   end
 end

--- a/spec/features/admins/admin_can_edit_user_profile_spec.rb
+++ b/spec/features/admins/admin_can_edit_user_profile_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe 'as an Admin' do
+  it 'allows admin to edit users profile' do
+    admin = create(:user, role: 2)
+    user_1 = create(:user)
+    user_2 = create(:user)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+    visit admin_user_path(user_1)
+
+    click_link "Edit Profile"
+
+    expect(current_path).to eq(edit_user_path(user_1))
+
+    admin = create(:user, role: 2)
+    user_1 = create(:user)
+    user_2 = create(:user)
+
+    new_name = "Wanda"
+    new_email = "wanda@aol.com"
+    new_password = "ILoveMom"
+    new_address = "125 Main St."
+    new_city = "Squirrel Town"
+    new_state = "CO"
+    new_zipcode = 12345
+
+    fill_in :user_name, with: new_name
+    fill_in :user_email, with: new_email
+    fill_in :user_password, with: new_password
+    fill_in :user_password_confirmation, with: new_password
+    fill_in :user_address, with: new_address
+    fill_in :user_city, with: new_city
+    fill_in :user_state, with: new_state
+    fill_in :user_zipcode, with: new_zipcode
+    binding.pry
+    click_on "Update User"
+    save_and_open_page
+    expect(current_path).to eq(admin_user_path(user_1))
+  end
+end


### PR DESCRIPTION
Closes #50 

Adds some new files for namespaced Admin and functionality so that the admin can edit a user's profile.

  ** There may be some conflicts in the users controller so that it updates a user correctly when the current_user.role = "admin"

All tests passing and includes sad path testing

----------------------------------------
User Story 22- Admin Can Edit User Profile

As an admin user
When I visit a user's profile page ("/admin/users/5")
And I click the link to edit the user's profile data
The same behaviors exist as if I were that user trying to change their own data
Except I am returned to the show page path of
"/admin/users/5" when I am finished