### PR TITLE
User story 24 redo

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,0 +1,4 @@
+class Admin::MerchantsController < ApplicationController
+  def show
+  end
+end 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -32,10 +32,4 @@ class Admin::UsersController < ApplicationController
       flash[:notice] = "#{@user.name}'s account is now disabled"
     end
   end
-
-private
-
-  def update_user_params
-    params.require(:user).permit(:active)
-  end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -15,6 +15,13 @@ class Admin::UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
 
+    if params[:upgrade]
+      @user.upgrade_to_merchant
+      flash[:success] = "Upgrade to Merchant Successful"
+      redirect_to admin_merchant_path
+      return
+    end
+
     if @user.active == false
       @user.enable
       redirect_to admin_users_path

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,4 +32,8 @@ class User < ApplicationRecord
   def disable
     update_column(:active, false)
   end
+
+  def upgrade_to_merchant
+    update_column(:role, "merchant")
+  end
 end

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -10,6 +10,7 @@
 </div>
 
 <%= link_to "Edit Profile", edit_admin_user_path(@user) %>
+<%= link_to "Upgrade to Merchant", admin_user_path(@user, upgrade: true), :method => :put %>
 
 <h2> All Orders </h2>
 <ul class="all-orders">

--- a/spec/features/admins/admin_upgrades_user_to_merchant_spec.rb
+++ b/spec/features/admins/admin_upgrades_user_to_merchant_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe 'as an Admin' do
+  before(:each) do
+    @admin = create(:user, role: 2)
+
+    visit root_path
+    click_link "Login"
+
+    fill_in :email, with: @admin.email
+    fill_in :password, with: @admin.password
+
+    click_button "Login"
+  end
+  it 'can upgrade a registered_user to be a merchant' do
+    user = create(:user)
+
+    visit admin_user_path(user.id)
+
+    expect(page).to have_link("Upgrade to Merchant")
+
+    click_link "Upgrade to Merchant"
+
+    expect(current_path).to eq(admin_merchant_path(user.id))
+    expect(page).to have_content("Upgrade to Merchant Successful")
+    expect(user.role).to eq("merchant")
+
+    expect(current_path).to_not eq(admin_user_path(user.id))
+    expect(user.role).to_not eq("registered_user")
+  end
+end

--- a/spec/features/admins/admin_upgrades_user_to_merchant_spec.rb
+++ b/spec/features/admins/admin_upgrades_user_to_merchant_spec.rb
@@ -23,9 +23,9 @@ describe 'as an Admin' do
 
     expect(current_path).to eq(admin_merchant_path(user.id))
     expect(page).to have_content("Upgrade to Merchant Successful")
-    expect(user.role).to eq("merchant")
+    expect(user.reload.role).to eq("merchant")
 
     expect(current_path).to_not eq(admin_user_path(user.id))
-    expect(user.role).to_not eq("registered_user")
+    expect(user.reload.role).to_not eq("registered_user")
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -75,12 +75,21 @@ RSpec.describe User, type: :model do
       expect(user_1.active).to eq(true)
       expect(user_1.active).to_not eq(false)
     end
+
     it 'changes a user from enabled to disabled' do
       user_1 = create(:user)
       user_1.disable
 
       expect(user_1.active).to eq(false)
       expect(user_1.active).to_not eq(true)
+    end
+
+    it 'changes a registered user to a merchant' do
+      user_1 = create(:user)
+      user_1.upgrade_to_merchant
+
+      expect(user_1.role).to eq("merchant")
+      expect(user_1.role).to_not eq("registered_user")
     end
   end
 end


### PR DESCRIPTION
***Created this new PR for User Story 24.  (close the other PR without being merged in because it was out of date now.)***

Passing feature & model tests for an admin to upgrade a registered user to a merchant.

closes #48 

User Story 24, Admin can make a User a Merchant

As an admin user
When I visit a user's profile page ("/admin/users/5")
I see a link to "upgrade" the user's account to become a merchant
When I click on that link
I am redirected to ("/admin/merchants/5") because the user is now a merchant
And I see a flash message indicating the user has been upgraded
The next time this user logs in they are now a merchant
Only admins can see the "upgrade" link
Only admins can reach any route necessary to upgrade the user to merchant status