### PR TITLE
User story 24, 43, 48, 49

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,4 +1,16 @@
 class Admin::MerchantsController < ApplicationController
   def show
+    @merchant = User.find(params[:id])
   end
-end 
+
+  def update
+    @merchant = User.find(params[:id])
+
+    if params[:downgrade]
+      @merchant.downgrade_to_user
+      flash[:success] = "Downgrade to User Successful"
+      redirect_to admin_user_path(@merchant.id)
+      return
+    end
+  end
+end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,0 +1,4 @@
+class Admin::MerchantsController < ApplicationController
+  def show
+  end
+end 

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,16 +1,30 @@
 class Admin::MerchantsController < ApplicationController
   def show
-    @merchant = User.find(params[:id])
+    @merchant = User.merchant.find(params[:id])
+  end
+
+  def index
+    @merchants = User.merchant
   end
 
   def update
-    @merchant = User.find(params[:id])
+    @merchant = User.merchant.find(params[:id])
 
     if params[:downgrade]
       @merchant.downgrade_to_user
       flash[:success] = "Downgrade to User Successful"
       redirect_to admin_user_path(@merchant.id)
       return
+    end
+
+    if @merchant.active == false
+      @merchant.enable
+      redirect_to admin_merchants_path
+      flash[:notice] = "#{@merchant.name}'s account is now enabled"
+    else
+      @merchant.disable
+      redirect_to admin_merchants_path
+      flash[:notice] = "#{@merchant.name}'s account is now disabled"
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -32,10 +32,4 @@ class Admin::UsersController < ApplicationController
       flash[:notice] = "#{@user.name}'s account is now disabled"
     end
   end
-
-private
-
-  def update_user_params
-    params.require(:user).permit(:active)
-  end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -15,6 +15,13 @@ class Admin::UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
 
+    if params[:upgrade]
+      @user.upgrade_to_merchant
+      flash[:success] = "Upgrade to Merchant Successful"
+      redirect_to admin_merchant_path
+      return
+    end
+
     if @user.active == false
       @user.enable
       redirect_to admin_users_path

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,4 +32,8 @@ class User < ApplicationRecord
   def disable
     update_column(:active, false)
   end
+
+  def upgrade_to_merchant
+    update_column(:role, "merchant")
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,4 +36,8 @@ class User < ApplicationRecord
   def upgrade_to_merchant
     update_column(:role, "merchant")
   end
+
+  def downgrade_to_user
+    update_column(:role, "registered_user")
+  end
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,1 +1,15 @@
-hello
+<section class="jumbotron">
+<h1>All Registered Users</h1>
+</section>
+
+<% @merchants.each do |merchant|%>
+<div id="merchant-<%= merchant.id %>">
+  <%= link_to merchant.name, admin_merchant_path(merchant.id) %>
+  <%= merchant.city %>, <%= merchant.state %>
+  <%if merchant.active == true %>
+    <%= button_to "disable", admin_merchant_path(merchant.id), method: :patch %>
+  <% else %>
+    <%= button_to "enable", admin_merchant_path(merchant.id), method: :patch %>
+  <% end %>
+</div>
+<%end%>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "Downgrade to User", admin_merchant_path(@merchant, downgrade: true), :method => :put %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -10,6 +10,7 @@
 </div>
 
 <%= link_to "Edit Profile", edit_admin_user_path(@user) %>
+<%= link_to "Upgrade to Merchant", admin_user_path(@user, upgrade: true), :method => :put %>
 
 <h2> All Orders </h2>
 <ul class="all-orders">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :users, only: [:index, :show, :edit, :update]
-    resources :merchants, only: [:show, :update]
+    resources :merchants, only: [:show, :index, :update]
     resources :orders, only: [:show]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :users, only: [:index, :show, :edit, :update]
-    resources :merchants, only: [:show]
+    resources :merchants, only: [:show, :update]
     resources :orders, only: [:show]
   end
 

--- a/spec/features/admins/admin_disables_and_enables_merchant_spec.rb
+++ b/spec/features/admins/admin_disables_and_enables_merchant_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+describe 'as an admin' do
+  describe "when on the users index page" do
+    before(:each) do
+      @admin_1 = create(:user, role: 2)
+      @admin_2 = create(:user, role: 2)
+      @admin_3 = create(:user, role: 2)
+
+      @merchant_1 = create(:user, role: 1)
+      @merchant_2 = create(:user, role: 1)
+      @merchant_3 = create(:user, role: 1, active: false)
+
+      @joe = create(:user)
+      @bob = create(:user)
+      @tom = create(:user)
+      @sally = create(:user, active: false)
+
+      visit root_path
+      click_link "Login"
+
+      fill_in :email, with: @admin_1.email
+      fill_in :password, with: @admin_1.password
+
+      click_button "Login"
+    end
+    it 'can disable a merchant' do
+      visit admin_merchants_path
+
+      within "#merchant-#{@merchant_1.id}" do
+        click_on "disable"
+      end
+
+      expect(current_path).to eq(admin_merchants_path)
+      expect(page).to have_content("#{@merchant_1.name}'s account is now disabled")
+
+      within "#merchant-#{@merchant_1.id}" do
+
+        expect(page).to have_button("enable")
+      end
+      expect(@merchant_1.reload.active).to be false
+    end
+
+      it 'can enable a merchant' do
+        visit admin_merchants_path
+
+        within "#merchant-#{@merchant_3.id}" do
+          click_on "enable"
+        end
+
+        expect(current_path).to eq(admin_merchants_path)
+        expect(page).to have_content("#{@merchant_3.name}'s account is now enabled")
+
+        within "#merchant-#{@merchant_3.id}" do
+          expect(page).to have_button("disable")
+        end
+
+        expect(@merchant_3.reload.active).to be true
+      end
+  end
+end

--- a/spec/features/admins/admin_downgrades_merchant_to_user_spec.rb
+++ b/spec/features/admins/admin_downgrades_merchant_to_user_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe 'as an Admin' do
+  before(:each) do
+    @admin = create(:user, role: 2)
+
+    visit root_path
+    click_link "Login"
+
+    fill_in :email, with: @admin.email
+    fill_in :password, with: @admin.password
+
+    click_button "Login"
+  end
+  it 'can downgrade a merchant to be a registered_user' do
+    merchant = create(:user, role: 1)
+
+    visit admin_merchant_path(merchant.id)
+
+    expect(page).to have_link("Downgrade to User")
+
+    click_link "Downgrade to User"
+
+    expect(current_path).to eq(admin_user_path(merchant.id))
+    expect(page).to have_content("Downgrade to User Successful")
+    expect(merchant.reload.role).to eq("registered_user")
+
+    expect(current_path).to_not eq(admin_merchant_path(merchant.id))
+    expect(merchant.reload.role).to_not eq("merchant")
+  end
+end

--- a/spec/features/admins/admin_upgrades_user_to_merchant_spec.rb
+++ b/spec/features/admins/admin_upgrades_user_to_merchant_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe 'as an Admin' do
+  before(:each) do
+    @admin = create(:user, role: 2)
+
+    visit root_path
+    click_link "Login"
+
+    fill_in :email, with: @admin.email
+    fill_in :password, with: @admin.password
+
+    click_button "Login"
+  end
+  it 'can upgrade a registered_user to be a merchant' do
+    user = create(:user)
+
+    visit admin_user_path(user.id)
+
+    expect(page).to have_link("Upgrade to Merchant")
+
+    click_link "Upgrade to Merchant"
+
+    expect(current_path).to eq(admin_merchant_path(user.id))
+    expect(page).to have_content("Upgrade to Merchant Successful")
+    expect(user.role).to eq("merchant")
+
+    expect(current_path).to_not eq(admin_user_path(user.id))
+    expect(user.role).to_not eq("registered_user")
+  end
+end

--- a/spec/features/admins/admin_upgrades_user_to_merchant_spec.rb
+++ b/spec/features/admins/admin_upgrades_user_to_merchant_spec.rb
@@ -23,9 +23,9 @@ describe 'as an Admin' do
 
     expect(current_path).to eq(admin_merchant_path(user.id))
     expect(page).to have_content("Upgrade to Merchant Successful")
-    expect(user.role).to eq("merchant")
+    expect(user.reload.role).to eq("merchant")
 
     expect(current_path).to_not eq(admin_user_path(user.id))
-    expect(user.role).to_not eq("registered_user")
+    expect(user.reload.role).to_not eq("registered_user")
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -75,12 +75,21 @@ RSpec.describe User, type: :model do
       expect(user_1.active).to eq(true)
       expect(user_1.active).to_not eq(false)
     end
+
     it 'changes a user from enabled to disabled' do
       user_1 = create(:user)
       user_1.disable
 
       expect(user_1.active).to eq(false)
       expect(user_1.active).to_not eq(true)
+    end
+
+    it 'changes a registered user to a merchant' do
+      user_1 = create(:user)
+      user_1.upgrade_to_merchant
+
+      expect(user_1.role).to eq("merchant")
+      expect(user_1.role).to_not eq("registered_user")
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -91,5 +91,13 @@ RSpec.describe User, type: :model do
       expect(user_1.role).to eq("merchant")
       expect(user_1.role).to_not eq("registered_user")
     end
+
+    it 'changes a merchant to a registered user' do
+      merchant_1 = create(:user, role: 1)
+      merchant_1.downgrade_to_user
+
+      expect(merchant_1.role).to eq("registered_user")
+      expect(merchant_1.role).to_not eq("merchant")
+    end
   end
 end


### PR DESCRIPTION
***Closed PR 140 & 114 (user-story-24-redo & user-story-24) without being merged in, as this PR includes all of those changes in one.***

closes #19 
closes #20 
cloes #26 
closes #48

Adds passing feature & model tests for an admin to be able to downgrade a merchant to a user or upgrade a user to a merchant, and enable and disable a merchant user.

User Story 49, Admin enables a merchant account
User Story 49, Admin disables a merchant account
User Story 43, Admin can downgrade a merchant to regular user
User Story 24, Admin can make a User a Merchant