### PR TITLE
Update item show

### DIFF
--- a/app/controllers/dashboard/orders_controller.rb
+++ b/app/controllers/dashboard/orders_controller.rb
@@ -1,0 +1,5 @@
+class Dashboard::OrdersController < ApplicationController
+  def show
+    @order = Order.find(params[:id])
+  end
+end

--- a/app/controllers/dashboard/orders_controller.rb
+++ b/app/controllers/dashboard/orders_controller.rb
@@ -1,5 +1,8 @@
 class Dashboard::OrdersController < ApplicationController
   def show
     @order = Order.find(params[:id])
+    @merchant = current_merchant
+    @items = @order.items.where(user_id: @merchant.id)
+    @order_items = OrderItem.orders_for_merchant(@order.id, @merchant.id)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -28,4 +28,8 @@ class Item < ApplicationRecord
       .where("order_items.fulfilled=?", true)
       .limit(5)
   end
+
+  def order_quantity(order)
+    order_items.where(order_id: order.id).pluck(:quantity).last
+  end
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -5,4 +5,8 @@ class OrderItem < ApplicationRecord
   def subtotal
     quantity * price
   end
+
+  def self.orders_for_merchant(order_id, user_id)
+    joins(:item).where('order_id =? AND user_id =?', order_id, user_id )
+  end
 end

--- a/app/views/dashboard/orders/show.html.erb
+++ b/app/views/dashboard/orders/show.html.erb
@@ -10,15 +10,12 @@
 </ul>
 
 <h2>Items Purchased from you:</h2>
-<% @order.items.each do |item| %>
-  <% if item.user_id == current_merchant.id %>
+<% @order_items.each do |o_item| %>
+  <% item = o_item.item %>
   <ul>
     <li>Item Name: <%= item.item_name %></li>
     <li><%= item.image_url %></li>
     <li>price: <%= item.price %></li>
-    <% if item.order_items.first.quantity == nil %>
-      <li>quantity: <%= item.order_items.first.quantity = 1 %></li>
-    <% end %>
-    </ul>
-  <% end %>
+    <li>quantity: <%= item.order_quantity(@order) %></li>
+  </ul>
 <% end %>

--- a/app/views/dashboard/orders/show.html.erb
+++ b/app/views/dashboard/orders/show.html.erb
@@ -1,0 +1,24 @@
+<h1>Dashboard Orders</h1>
+
+<h2>Purchaser Info:</h2>
+<h4>Name: <%= @order.user.name %></h4>
+<ul>
+  <li><%= @order.user.address %></li>
+  <li><%= @order.user.city %></li>
+  <li><%= @order.user.state %></li>
+  <li><%= @order.user.zipcode %></li>
+</ul>
+
+<h2>Items Purchased from you:</h2>
+<% @order.items.each do |item| %>
+  <% if item.user_id == current_merchant.id %>
+  <ul>
+    <li>Item Name: <%= item.item_name %></li>
+    <li><%= item.image_url %></li>
+    <li>price: <%= item.price %></li>
+    <% if item.order_items.first.quantity == nil %>
+      <li>quantity: <%= item.order_items.first.quantity = 1 %></li>
+    <% end %>
+    </ul>
+  <% end %>
+<% end %>

--- a/spec/features/merchants/merchant_visits_order_spec.rb
+++ b/spec/features/merchants/merchant_visits_order_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe 'when a merchant visits orders show page' do
+  before(:each) do
+    @user_1 = create(:user)
+    @merchant = create(:user, role: 1)
+    @item_1 = create(:item, user: @merchant, price: 100.00)
+    @item_2 = create(:item, user: @merchant, price: 101.00)
+    @order_1 = create(:order, user: @user_1, items: [@item_1, @item_1, @item_2])
+    @order_item_1 = create(:order_item, order: @order_1, quantity: 1, price: 301.00)
+
+    visit root_path
+    click_link "Login"
+
+    fill_in :email, with: @merchant.email
+    fill_in :password, with: @merchant.password
+
+    click_button "Login"
+  end
+  it 'merchant can see the customers name and address' do
+    visit dashboard_order_path(@order_1)
+
+    expect(page).to have_content(@order_1.user.name)
+    expect(page).to have_content(@order_1.user.address)
+    expect(page).to have_content(@order_1.user.city)
+    expect(page).to have_content(@order_1.user.state)
+    expect(page).to have_content(@order_1.user.zipcode)
+    expect(page).to have_content(@item_1.item_name)
+    expect(page).to have_content(@item_1.image_url)
+    expect(page).to have_content(@item_1.price)
+    expect(page).to have_content(@item_2.item_name)
+    expect(page).to have_content(@order_item_1.quantity)
+  end
+end

--- a/spec/features/merchants/merchant_visits_order_spec.rb
+++ b/spec/features/merchants/merchant_visits_order_spec.rb
@@ -7,7 +7,8 @@ describe 'when a merchant visits orders show page' do
     @item_1 = create(:item, user: @merchant, price: 100.00)
     @item_2 = create(:item, user: @merchant, price: 101.00)
     @order_1 = create(:order, user: @user_1, items: [@item_1, @item_1, @item_2])
-    @order_item_1 = create(:order_item, order: @order_1, quantity: 1, price: 301.00)
+    @order_item_1 = create(:order_item, order: @order_1, item: @item_1, quantity: 2, price: 200.00)
+    @order_item_2 = create(:order_item, order: @order_1, item: @item_2, quantity: 1, price: 101.00)
 
     visit root_path
     click_link "Login"
@@ -30,5 +31,6 @@ describe 'when a merchant visits orders show page' do
     expect(page).to have_content(@item_1.price)
     expect(page).to have_content(@item_2.item_name)
     expect(page).to have_content(@order_item_1.quantity)
+    expect(page).to have_content(@order_item_2.quantity)
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -50,5 +50,16 @@ RSpec.describe Item, type: :model do
 
       expect(item_1.total_for_item).to eq(123)
     end
+    it 'can check order quantity for merchant item' do
+      user = create(:user, role: 1)
+      item_1 = create(:item, user: user)
+
+      order_1 = create(:order, user: user)
+      create(:order_item, order: order_1, item: item_1, price: 2.5, quantity: 5)
+
+      query = item_1.order_quantity(order_1)
+
+      expect(query).to eq(5)
+    end
   end
 end

--- a/spec/models/order_items_spec.rb
+++ b/spec/models/order_items_spec.rb
@@ -17,7 +17,18 @@ RSpec.describe OrderItem, type: :model do
 
       expect(order_item_1.subtotal).to eq(12.5)
     end
-    
-  end
+    it 'can find orders for merchant' do
+      user = create(:user, role: 1)
+      item_1 = create(:item, user: user)
+      item_2 = create(:item, user: user)
 
+      order_1 = create(:order, user: user)
+      order_item_1 = create(:order_item, order: order_1, item: item_1, price: 2.5, quantity: 5)
+      order_item_2 = create(:order_item, order: order_1, item: item_2, price: 3.1, quantity: 10)
+
+      query = OrderItem.orders_for_merchant(order_1.id, user.id)
+
+      expect(query).to eq([order_item_1, order_item_2])
+    end
+  end
 end


### PR DESCRIPTION
closes #7 

As a merchant
When I visit an order show page from my dashboard
I see the customer's name and address
I only the items in the order that are being purchased from my inventory
I do not see any items in the order being purchased from other merchants
For each item, I see the following information:
- the name of the item, which is a link to my item's show page
- a small thumbnail of the item
- my price for the item
- the quantity the user wants to purchase
